### PR TITLE
docs: recommend eslint.config.ts, add troubleshooting for .js config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ export default [
 
 ### Recommended config (TypeScript project)
 
-Create `eslint.config.ts` (or `eslint.config.js`) with the TypeScript parser
-and the plugin's recommended rules:
+Create `eslint.config.ts` with the TypeScript parser and the plugin's
+recommended rules:
 
 ```ts
 // eslint.config.ts
@@ -289,6 +289,24 @@ export default [
   },
 ];
 ```
+
+### Troubleshooting
+
+**`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` when loading the plugin**
+
+If you see:
+
+```
+Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
+unsupported for files under node_modules, for .../eslint-plugin-jax-js/src/index.ts
+```
+
+your ESLint config file is probably `eslint.config.js`. Node's built-in type
+stripping does not apply to files inside `node_modules`, so ESLint cannot load
+the plugin's TypeScript source when the config itself is a plain `.js` file.
+
+**Fix:** rename your config to `eslint.config.ts`. ESLint then uses `jiti` to
+load the config **and** the plugin, bypassing Node's `node_modules` restriction.
 
 ## IDE Integration
 


### PR DESCRIPTION
Fixes #3

### Problem

When the ESLint config file is `eslint.config.js` (not `.ts`), Node's built-in type stripping refuses to process `.ts` files under `node_modules`, causing:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]: Stripping types is currently
unsupported for files under node_modules, for .../eslint-plugin-jax-js/src/index.ts
```

Renaming to `eslint.config.ts` makes ESLint use `jiti` for the entire load chain, which handles `node_modules` TypeScript fine.

### Changes

- Remove `(or eslint.config.js)` from the Setup heading — `.ts` is the only reliably working option.
- Add a **Troubleshooting** section after the setup examples explaining the error and the fix.