### PR TITLE
docs: change VS Code eslint.run to onType

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Optional settings for a better experience (add to `.vscode/settings.json`):
 
 ```jsonc
 {
-  // Lint on save for fast feedback
-  "eslint.run": "onSave",
+  // Lint as you type for immediate feedback (use "onSave" if you prefer less frequent diagnostics)
+  "eslint.run": "onType",
 
   // Validate TypeScript and JavaScript files
   "eslint.validate": ["typescript", "javascript"],


### PR DESCRIPTION
Fixes #5

Changes `"eslint.run": "onSave"` to `"onType"` in the recommended VS Code settings snippet, with a note that `onSave` is an alternative. This gives users immediate edit-time diagnostics (squiggles while typing), which is the primary value of the plugin.