### PR TITLE
fix(no-use-after-consume): allow .refCount access after dispose

### DIFF
--- a/test/no-use-after-consume.test.ts
+++ b/test/no-use-after-consume.test.ts
@@ -255,6 +255,9 @@ describe("no-use-after-consume", () => {
 
         // Boolean() is safe-listed
         "const x = np.zeros([3]); Boolean(x); x.dispose();",
+
+        // .refCount after dispose — allowed for leak checking
+        "const x = np.array([1, 2, 3]); x.dispose(); expect(x.refCount).toBe(0);",
       ],
 
       invalid: [


### PR DESCRIPTION
## Summary

Allow `.refCount` property access after an array has been consumed/disposed, since this is the standard pattern for leak checking in tests:

```ts
const x = np.array([1, 2, 3]);
expect(x.refCount).toBe(1);
x.dispose();
expect(x.refCount).toBe(0); // no longer flagged
```

## Changes

- **`src/rules/no-use-after-consume.ts`**: Add `SAFE_AFTER_DISPOSE_PROPS` set (`refCount`) and `isSafeAfterDisposeAccess()` helper. Insert early `continue` in the main loop before the error report.
- **`test/no-use-after-consume.test.ts`**: Add valid test case for `.refCount` after `.dispose()`.

Other property accesses (`.shape`, `.dtype`, etc.) after dispose are still flagged.

Closes #11